### PR TITLE
Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "stechstudio/sdk",
     "require": {
         "tedivm/stash": "0.16.*",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
Laravel 10 requires Monolog 3 which adheres to a newer version of the `psr/log` interface. The only API difference between major [versions 1 to 2](https://github.com/php-fig/log/compare/1.1.4...2.0.0) is the addition of parameter type hints and the only difference between [versions 2 to 3](https://github.com/php-fig/log/compare/2.0.0...3.0.0) is the addition of return types. There are no breaking changes, so I think allowing any version of the interface to be included is acceptable and won't require other code changes in this repo.