### PR TITLE
Laravel 10.x | Guzzle 7.x PHP | 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "dev-master",
         "laravel/helpers": "^1.1",
-        "guzzlehttp/guzzle": "^6.1",
-        "laravel/framework": "^8.0"
+        "guzzlehttp/guzzle": "^7.0",
+        "laravel/framework": "^10.0"
     },
     "authors": [
         {

--- a/src/Request.php
+++ b/src/Request.php
@@ -5,6 +5,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Stash\Pool;
 use STS\Sdk\CircuitBreaker\BreakerPanel;
 use STS\Sdk\CircuitBreaker\BreakerSwitch;
@@ -125,7 +126,7 @@ class Request
      */
     public function setBody($contents)
     {
-        $this->request = $this->request->withBody(Psr7\stream_for($contents));
+        $this->request = $this->request->withBody(Utils::streamFor($contents));
     }
 
     /**


### PR DESCRIPTION
To support the Internal Laravel upgrade from 8.x to 10.x.

Mainly replaces `Psr7\stream_for` with `Utils::streamFor`.